### PR TITLE
Doc fixes: URL and typo

### DIFF
--- a/docs/cpp/ide/arduino.md
+++ b/docs/cpp/ide/arduino.md
@@ -19,7 +19,7 @@ To install and configure your arduino IDE, please use the following steps:
 `https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json`
 
 
-3. Now open `Tools/Boards Manager` and install `esp32 by espressif systems` You need at least version 2.02. Check Boards Manager URL abobe, if only 1.x versions are listed.
+3. Now open `Tools/Boards Manager` and install `esp32 by espressif systems` You need at least version 2.02. Check Boards Manager URL above, if only 1.x versions are listed.
 
 4. Our ftSwarm firmware and library has some dependencies. Please install the following libraries using `Tools\Manage Libraries`:
     - `Adafruit GFX Library`, at least version 1.10.12

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ td, th {
 |---|---|
 | As a control panel, the ftSwarmControl has, in addition to 2 joysticks, 8 buttons and an LCD display, the ability to control 2 DC motors and read 4 digital sensors.| ![ftSwarmControl](assets/img/ftSwarmControl_small.png) | 
 
-Since building this hardware on your own is a little bit tricky, we offer ready to use devices at [www.gundermann.org](www.gundermann.org).
+Since building this hardware on your own is a little bit tricky, we offer ready to use devices at [gundermann-software.de](https://gundermann-software.de/).
 For all who want's to build their own pcb, we provide the needed schematic files at github as well.
 
 [Let's start!](../ftSwarm/startReading){: .btn .float-right } 


### PR DESCRIPTION
Fixed URL for Gundermann soft-/hardware website and a typo