### PR TITLE
esp32 lib: Added hint for max. version 2.0.3

### DIFF
--- a/docs/cpp/ide/arduino.md
+++ b/docs/cpp/ide/arduino.md
@@ -18,8 +18,7 @@ To install and configure your arduino IDE, please use the following steps:
 <br>
 `https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json`
 
-
-3. Now open `Tools/Boards Manager` and install `esp32 by espressif systems` You need at least version 2.02. Check Boards Manager URL above, if only 1.x versions are listed.
+3. Now open `Tools/Boards Manager` and install `esp32 by espressif systems`. Please use at least version 2.0.2 and currently at most version 2.0.3. Check Boards Manager URL above, if only 1.x versions are listed.
 
 4. Our ftSwarm firmware and library has some dependencies. Please install the following libraries using `Tools\Manage Libraries`:
     - `Adafruit GFX Library`, at least version 1.10.12


### PR DESCRIPTION
Added hint to use max. version 2.0.3 of the Espressif lib