### PR TITLE
Fix: unsubscribe only when initialized

### DIFF
--- a/src/ftswarm-core/src/SwOSSwarm.cpp
+++ b/src/ftswarm-core/src/SwOSSwarm.cpp
@@ -396,10 +396,11 @@ void SwOSSwarm::halt( void ) {
 }
 
 void SwOSSwarm::unsubscribe( void ) {
-
   for (uint8_t i=0; i<=maxCtrl; i++)
-    Ctrl[i]->unsubscribe( true );
-
+    if ( Ctrl[i])
+      Ctrl[i]->unsubscribe( true );
+    else
+      printf("[ERROR]: unsubscribe: Ctrl[%d] is NULL\n", i );
 }
 
 uint8_t SwOSSwarm::getIndex( FtSwarmSerialNumber_t serialNumber ) {


### PR DESCRIPTION
This should fix the following error:

```
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x420a56b0  PS      : 0x00060230  A0      : 0x8200f1a6  A1      : 0x3fcebdc0  
A2      : 0x3fc9db20  A3      : 0x00000003  A4      : 0x00000001  A5      : 0x00000000  
A6      : 0x3fcf1b70  A7      : 0x00000000  A8      : 0x3fc9db38  A9      : 0x3fcebda0  
A10     : 0x00000000  A11     : 0x00000001  A12     : 0x3fcc0d9c  A13     : 0x00000000  
A14     : 0x3fcf05e4  A15     : 0x00000001  SAR     : 0x00000020  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000000  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffff9  


Backtrace: 0x420a56ad:0x3fcebdc0 0x4200f1a3:0x3fcebde0 0x420104ef:0x3fcebe00 0x42005399:0x3fcebe20 0x420040ef:0x3fcec000 0x42012fd6:0x3fcec030

  #0  0x420a56ad:0x3fcebdc0 in SwOSSwarm::unsubscribe() at /home/user/ftSwarm/src/ftswarm-core/src/SwOSSwarm.cpp:400 (discriminator 2)
  #1  0x4200f1a3:0x3fcebde0 in SwOSCLI::startCLI(bool) at /home/user/ftSwarm/src/ftswarm-core/src/SwOSCLI.cpp:214
  #2  0x420104ef:0x3fcebe00 in SwOSCLI::run() at /home/user/ftSwarm/src/ftswarm-core/src/SwOSCLI.cpp:1034
  #3  0x42005399:0x3fcebe20 in firmware() at /home/user/ftSwarm/src/ftswarm-core/src/SwOSFirmware.cpp:825
  #4  0x420040ef:0x3fcec000 in setup() at src/main.cpp:8
  #5  0x42012fd6:0x3fcec030 in loopTask(void*) at /home/user/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:42


ELF file SHA256: 8eeecb8c3044a0ab
```